### PR TITLE
Experimental automated testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+
+*~

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/rdp-test-helper-jpext"]
+	path = test/rdp-test-helper-jpext
+	url = https://github.com/rpl/rdp-test-helper-jpext.git

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,97 @@
+/*global module:false*/
+module.exports = function(grunt) {
+
+  // Project configuration.
+  grunt.initConfig({
+    // Task configuration.
+    jshint: {
+      options: {
+        curly: true,
+        eqeqeq: true,
+        immed: true,
+        latedef: true,
+        newcap: true,
+        noarg: true,
+        sub: true,
+        undef: true,
+        unused: true,
+        boss: true,
+        eqnull: true,
+        browser: false,
+        globals: {
+          require: true
+        }
+      },
+      gruntfile: {
+        src: 'Gruntfile.js'
+      },
+      lib_test: {
+        src: ['lib/**/*.js', 'test/**/*.js']
+      }
+    },
+    watch: {
+      gruntfile: {
+        files: '<%= jshint.gruntfile.src %>',
+        tasks: ['jshint:gruntfile']
+      },
+      lib_test: {
+        files: '<%= jshint.lib_test.src %>',
+        tasks: ['test'] //, 'jshint:lib_test']
+      }
+    }
+  });
+
+  // These plugins provide necessary tasks.
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-contrib-watch');
+
+  // Default task.
+  grunt.registerTask('default', ['jshint']);
+
+  // DEFINE CUSTOM TASKS
+  grunt.registerTask('test', ['test-server', 'firefox-run']);
+
+  grunt.registerTask('test-server', 'Run the test server', function() {
+    require('./test');
+  });
+  grunt.registerTask('firefox-run', 'Run Firefox using cfx', function() {
+    var done = this.async();
+    var rdp_helper_addon_dir = process.env.FIREFOX_ADDON_DIR || "./test/rdp-test-helper-jpext";
+
+    grunt.log.writeln('running firefox ...');
+    // And some async stuff.
+    var options = this.options();
+    var cmdPath = process.env.CFX_BIN || "./addon-sdk/bin/cfx";
+
+    var args = [
+      "run",
+      "-b", process.env.FIREFOX_BIN || require('which').sync('firefox'),
+    ];
+
+    grunt.log.writeln("CMD: "+cmdPath);
+
+    var spawn = grunt.util.spawn({
+      cmd: cmdPath,
+      args: args,
+      opts: {
+        cwd: rdp_helper_addon_dir,
+        env: {
+          MINIMIZE: 1,
+          DISPLAY: process.env.DISPLAY,
+          PYTHON_PATH: process.env.FIREFOX_ADDON_DIR+"/python-lib:"+process.env.PYTHON_PATH,
+          PATH: process.env.FIREFOX_ADDON_DIR+"/bin:"+process.env.PATH,
+          RDP_LISTEN_PORT: 6000,
+          RDP_CONNECT_TO: "localhost:5001"
+        }
+      }
+    }, function(err, result, code) {
+      grunt.log.writeln('"firefox run" done (exit code: '+code+').');
+      done();
+    });
+
+//    spawn.stdout.on("data", function (data) { console.log("STDOUT", data.toString()) });
+//    spawn.stderr.on("data", function (data) { console.log("STDERR", data.toString()) });
+
+    return spawn;
+  });
+};

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -2,7 +2,8 @@ var extend = require("./extend"),
     ClientMethods = require("./client-methods"),
     Client = require("./client"),
     Tab = require("./tab"),
-    SimulatorApps = require("./simulator");
+    SimulatorApps = require("./simulator"),
+    RDPTestHelper = require("./rdp-test-helper");
 
 const DEFAULT_PORT = 6000;
 const DEFAULT_HOST = "localhost";
@@ -20,6 +21,13 @@ function FirefoxClient() {
 }
 
 FirefoxClient.prototype = extend(ClientMethods, {
+  get RDPTestHelper() {
+    if (!this._RDPTestHelper) {
+      this._RDPTestHelper = new RDPTestHelper(this.client, this.RDPTestHelperActor);
+    }
+    return this._RDPTestHelper;
+  },
+
   connect: function(port, host, cb) {
     if (typeof port == "function") {
       // (cb)
@@ -62,6 +70,10 @@ FirefoxClient.prototype = extend(ClientMethods, {
       if (err) {
         return cb(err);
       }
+
+	  if (resp.RDPTestHelperActor) {
+        this.RDPTestHelperActor = resp.RDPTestHelperActor;
+	  }
 
       if (resp.simulatorWebappsActor) {
         // the server is the Firefox OS Simulator, return apps as "tabs"

--- a/lib/network.js
+++ b/lib/network.js
@@ -91,15 +91,12 @@ NetworkEvent.prototype = extend(ClientMethods, {
       "responseCookies": "response-cookies",
       "responseContent": "response-content",
       "eventTimings": "event-timings"
+    };
+
+    var type = types[event.updateType];
+
+    if(type) {
+      this.emit(type, event.updateType, event);
     }
-
-    var type = event.updateType;
-    delete event.updateType;
-
-    this.emit(type, event);
   }
 })
-
-
-
-

--- a/lib/rdp-test-helper.js
+++ b/lib/rdp-test-helper.js
@@ -1,0 +1,17 @@
+var extend = require("./extend"),
+    ClientMethods = require("./client-methods");
+
+module.exports = RDPTestHelper;
+
+function RDPTestHelper(client, actor) {
+  this.initialize(client, actor);
+}
+
+RDPTestHelper.prototype = extend(ClientMethods, {
+  openTab: function(url, cb) {
+    this.request('openTab', {url: url}, cb);
+  },
+  exitApp: function(cb) {
+    this.request('exitApp', cb);
+  }
+});

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,63 @@
+var net = require('net'),
+    extend = require("./extend"),
+    Client = require("./client"),
+    FirefoxClient = require("./browser");
+
+var clients = [];
+
+function passiveConnect(client, socket) {
+  client._conn = socket.host + ":" + socket.port;
+  client._socket = socket;
+  client.client = socket;
+  socket.on("data", client.onData.bind(client));
+  socket.on("error", client.onError.bind(client));
+  socket.on("end", client.onEnd.bind(client));
+  socket.on("timeout", client.onTimeout.bind(client));
+
+  return client;
+}
+
+
+net.createServer(function (socket) {
+  clients.push(socket);
+
+  var tab_listed = false;
+  var tab, Console;
+
+  console.log("Connected from " + socket + "\n");
+
+  socket.on('data', function (data) {
+    if (!tab_listed) {
+      var client = new Client();
+      socket.client = passiveConnect(client, socket);
+      socket.client.expectReply(this.actor, function(packet) {
+        console.log("PACKET", packet);
+      });
+
+      tab_listed = true;
+      var firefox_client = new FirefoxClient();
+      firefox_client.initialize(socket.client, 'root');
+      firefox_client.listTabs(function(err, tabs) {
+        console.log("REPLY", tabs[0]);
+        tab = tabs[0];
+
+        tab.attach(function () {
+          Console = tab.Console;
+          Console.evaluateJS("alert('ok');", function () { console.log("DUMP", arguments); });
+          Console.getCachedLogs(function (err, messages) {
+            console.log("MESSAGES: ", messages);
+          });
+        });
+      });
+    }
+    //console.log("DATA: "+data);
+  });
+
+  socket.on('end', function () {
+    clients.splice(clients.indexOf(socket), 1);
+    console.log("CLOSE: "+socket.client.conn);
+  });
+}).listen(5001);
+
+// Put a friendly message on the terminal of the server.
+console.log("RDP server running at port 5001\n");

--- a/package.json
+++ b/package.json
@@ -14,8 +14,12 @@
     "js-select": "~0.6.0"
   },
   "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-contrib-jshint": "~0.6.2",
+    "mocha": "~1.12.0",
     "connect": "~2.8.2",
-    "mocha": "~1.12.0"
+    "which": "~1.0.5",
+    "grunt-contrib-watch": "~0.5.1"
   },
   "keywords": [
     "firefox",

--- a/test.js
+++ b/test.js
@@ -1,153 +1,49 @@
-var FirefoxClient = require("./lib/browser.js");
+var RDPServer = require("./test/rdp-server.js");
+var HTTPServer = require("./test/http-server.js");
 
-var client = new FirefoxClient();
+RDPServer.listen(5001);
+HTTPServer.listen(3000);
 
-client.connect(function() {
-  client.listTabs(function(err, tabs) {
-    var tab = tabs[0];
-    testTab(tab);
+var Mocha = require('mocha'),
+    fs = require('fs'),
+    path = require('path');
+
+var mocha = new Mocha();
+
+function load() {
+  fs.readdirSync('test/').filter(function(file){
+    // Only keep the test-*.js files
+    return file.substr(0,5) === "test-" && file.substr(-3) === '.js';
+  }).forEach(function(file){
+    console.log("ADD TEST FILE:", file);
+    mocha.addFile(
+      path.join('test/', file)
+    );
   });
+}
+
+function purge() {
+  mocha.files.forEach(function(file){
+      delete require.cache[file];
+  });
+}
+
+function run(client) {
+  try {
+    mocha.ui('tdd').run(function(failures){
+      console.log("FAILURES: ", failures);
+      RDPServer.exitConnectedClient(client);
+      purge();
+      process.exit(failures > 0 ? 1: 0);
+    });
+  } catch(e) {
+    console.log("EXCEPTION: ", e);
+    process.exit(1);
+  }
+}
+
+RDPServer.on("connected", function (client) {
+  mocha.reporter('list');
+  load();
+  run(client);
 });
-
-function testCachedLogs(tab) {
-  tab.Console.startLogging(function() {
-    console.log("started logging");
-    tab.Console.getCachedLogs(function(err, resp) {
-      console.log("cached", resp);
-    });
-    tab.Console.getCachedLogs(function(err, resp) {
-      console.log("cached", resp);
-    });
-
-  })
-}
-
-function testTab(tab) {
-  //testCachedLogs(tab);
-  //testAttach(tab);
-  testReload(tab);
-  //testNavigateTo(tab);
-  //testDOM(tab);
-  //testLogs(tab);
-  //testNetwork(tab);
-  //testConsole(tab);
-}
-
-function testAttach(tab) {
-  tab.attach(function(resp) {
-    console.log("attach resp:", resp);
-  });
-}
-
-function testReload(tab) {
-  tab.DOM.document(function(err, doc) {
-    console.log("hola", doc.actor);
-  });
-  tab.attach(function(err, resp) {
-    if (err) throw err;
-
-    tab.on("navigate", function() {
-      tab.DOM.document(function(err, doc) {
-        if (err) throw err.message;
-        console.log("hola again", doc.actor);
-      });
-    })
-    tab.reload();
-  });
-}
-
-function testNavigateTo(tab) {
-  tab.navigateTo("http://www.google.com");
-}
-
-function testConsole(tab) {
-  tab.Console.evaluateJS("window", function(resp) {
-    var result = resp.result;
-
-  //  result.ownPropertyNames(function(names) {
-  //    console.log("num properties: ", names.length);
-  //  });
-
-    result.prototype(function(resp) {
-      console.log(resp);
-    })
-
-    result.propertyValue('document', function(value) {
-      console.log("document value:", value.class);
-    })
-  });
-}
-
-function testNetwork(tab) {
-  tab.Network.on("network-event", function(event) {
-    console.log("network event: ", event.url);
-  });
-
-  tab.Network.startLogging();
-
-  var request = {
-    url: "https://github.com/harthur/some-json/raw/gh-pages/1.json",
-    method: "GET",
-    headers: [{name: "test-header", value: "test-value"}]
-  };
-
-  tab.Network.sendHTTPRequest(request, function(networkEvent) {
-    networkEvent.getResponseHeaders(function(message) {
-        console.log("got event headers:" +  JSON.stringify(message));
-    })
-
-    networkEvent.on("update", function(type, data) {
-      console.log("on update " + type);
-      if (type == "responseContent") {
-        networkEvent.getResponseContent(function(message) {
-          console.log("got event headers:" +  JSON.stringify(message));
-        })
-      }
-    })
-  });
-}
-
-function testLogs(tab) {
-  tab.Logs.getLogs(function(resp) {
-    console.log("logs:", resp);
-  });
-
-  tab.Logs.on("page-error", function(error) {
-    console.log("received error: " + error.errorMessage);
-  });
-  tab.Logs.on("console-api-call", function(call) {
-    console.log("made console call: console." + call.level + "()");
-  });
-  tab.Logs.startLogging();
-}
-
-function testStyleSheets(tab) {
-  tab.StyleSheets.addStyleSheet("* { color: red; } ", function(sheet) {
-    console.log("added style sheet to document ", sheet.ruleCount);
-  });
-}
-
-function testDOM(tab) {
-  tab.DOM.document(function(doc) {
-    doc.querySelector(".event", function(node) {
-      node.outerHTML(function(html) {
-        //console.log(html);
-      });
-
-      node.siblings(function(siblings) {
-        console.log(siblings.length);
-      });
-
-      node.nextSibling(function(sibling) {
-        console.log(sibling.nodeName);
-      });
-
-      var className = node.getAttribute("class");
-      console.log("class: ", className);
-
-      node.setAttribute("class", "no-class", function() {
-        console.log("attr set");
-      })
-    })
-  })
-}

--- a/test/http-server.js
+++ b/test/http-server.js
@@ -1,0 +1,4 @@
+var path = require("path"),
+    connect = require('connect');
+
+module.exports = connect.createServer(connect.static(path.join(__dirname, "pages")));

--- a/test/server.js
+++ b/test/server.js
@@ -1,8 +1,0 @@
-var path = require("path"),
-    connect = require('connect');
-
-var port = 3000;
-
-connect.createServer(connect.static(path.join(__dirname, "pages"))).listen(port);
-
-console.log("visit:\nhttp://127.0.0.1:" + port + "/index.html");

--- a/test/test-network.js
+++ b/test/test-network.js
@@ -56,15 +56,16 @@ describe('sendHTTPRequest()', function() {
 // event:update
 
 
-describe('getRequestHeaders(', function() {
+describe('getRequestHeaders()', function() {
   it('should get request headers', function(done) {
     Network.once('network-event', function(netEvent) {
+      assert.ok(netEvent);
       netEvent.on("request-headers", function(type, event) {
         assert.ok(event.headers);
         assert.ok(event.headersSize);
 
         netEvent.getRequestHeaders(function(err, resp) {
-          var found = resp.some(function(header) {
+          var found = resp.headers.some(function(header) {
             return header.name == "test-header" &&
                    header.value == "test-value";
           })
@@ -78,7 +79,7 @@ describe('getRequestHeaders(', function() {
 })
 
 // TODO: NetworkEvent tests
-
+;
 after(function() {
   Network.stopLogging(function(err) {
     assert.strictEqual(err, null);

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,32 +4,17 @@ var assert = require('assert'),
 var tab;
 
 exports.loadTab = function(url, callback) {
-  getFirstTab(function(tab) {
-    tab.navigateTo(url);
-
-    tab.once("navigate", function() {
-      callback(tab);
-    });
-  })
-};
-
-
-function getFirstTab(callback) {
-  if (tab) {
-    return callback(tab);
-  }
   var client = new FirefoxClient();
 
   client.connect(function() {
     client.listTabs(function(err, tabs) {
-      if (err) throw err;
-
-      tab = tabs[0];
-
-      tab.attach(function(err) {
-        if (err) throw err;
-        callback(tab);
-      })
+      client.RDPTestHelper.openTab("localhost:3000/"+url, function (err, res) {
+        var tabIndex = res.tabIndex;
+        client.listTabs(function (err, tabs) {
+          var tab= tabs[tabIndex];
+          callback(tab);
+        });
+      });
     });
   });
-}
+};


### PR DESCRIPTION
This pull request contains:
- "test/rdp-test-helper-jpext" submodule (needed to spawn instrumented firefox instances)
- "test/rdp-server.js" (needed to receive firefox instance connection and control the connected clients, e.g. exit the app)
- changes to "lib/browser.js" to integrate the RDPTestHelperActor
- "Gruntfile.js" (needed to automate the process)
- minor tweaks
