### PR TITLE
Improve compatibility with XULRunner applications

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -61,6 +61,11 @@ FirefoxClient.prototype = extend(ClientMethods, {
 
   selectedTab: function(cb) {
     this.request("listTabs", function(resp) {
+	  if (resp.tabs.length == 0) {
+		// If there are no tabs, connect to the application itself
+		// (mostly useful for xulrunner apps, which may not have tabs)
+		return new Tab(this.client, resp);
+	  }
       var tab = resp.tabs[resp.selected];
       return new Tab(this.client, tab);
     }.bind(this), cb);
@@ -77,6 +82,11 @@ FirefoxClient.prototype = extend(ClientMethods, {
         var apps = new SimulatorApps(this.client, resp.simulatorWebappsActor);
         apps.listApps(cb);
       }
+	  else if (resp.tabs.length == 0) {
+		// If there are no tabs, connect to the application itself
+		// (mostly useful for xulrunner apps, which may not have tabs)
+		return [new Tab(this.client, resp)];
+	  }
       else {
         var tabs = resp.tabs.map(function(tab) {
           return new Tab(this.client, tab);


### PR DESCRIPTION
XULRunner apps are not required to have tabs, so add a fallback to
connect to the application as a whole.
