### PR TITLE
Add support for webapps actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ var FirefoxClient = require("firefox-client");
 var client = new FirefoxClient();
 
 client.connect(6000, function() {
-  client.listTabs(function(err, tabs, actors) {
+  client.listTabs(function(err, tabs) {
     console.log("first tab:", tabs[0].url);
   });
 });
@@ -42,14 +42,13 @@ A limited set of the API (`Console`, `StyleSheets`) is compatible with the [Simu
 
 ### Firefox OS 1.2+ Simulator and devices
 
-`client.listTabs()` will expose the webapps actor, with various utility function around webapps and also allows to have `Tab` instances for each running app.
+`client.listTabs()` will expose the webapp, with various utility function around webapps and also allows to have `Tab` instances for each running app.
 
 ```
-client.listTabs(function(err, tabs, actors) {
-  var webapps = actors.webapps;
-  webapps.getAppActor("app://homescreen.gaiamobile.org/manifest.webapp", function (err, actor) {
+client.Webapps(function(err, webapps) {
+  webapps.getApp("app://homescreen.gaiamobile.org/manifest.webapp", function (err, app) {
     console.log("homescreen:", actor.url);
-    actor.Console.evaluateJS("alert('foo')", function(err, resp) {
+    app.Console.evaluateJS("alert('foo')", function(err, resp) {
       console.log("alert dismissed");
     });
   });
@@ -88,7 +87,7 @@ tab.Console.on("page-error", function(event) {
 Summary of the offerings of the modules and objects:
 
 #### [FirefoxClient](http://github.com/harthur/firefox-client/wiki/FirefoxClient)
-Methods: `connect()`, `disconnect()`, `listTabs()`, `selectedTab()`
+Methods: `connect()`, `disconnect()`, `listTabs()`, `selectedTab()`, `Webapps()`, `Root()`
 
 Events: `"error"`, `"timeout"`, `"end"`
 
@@ -140,7 +139,7 @@ Methods: `getText()`, `update()`, `toggleDisabled()`, `getOriginalSources()`
 Events: `"disabled-changed"`, `"ruleCount-changed"`
 
 #### Webapps
-Methods: `listRunningApps()`, `getInstalledApps()`, `watchApps()`, `unwatchApps()`, `launch()`, `close()`, `getAppActor()`, `installHosted()`, `installPackaged()`, `installPackagedWithADB()`, `uninstall()
+Methods: `listRunningApps()`, `getInstalledApps()`, `watchApps()`, `unwatchApps()`, `launch()`, `close()`, `getApp()`, `installHosted()`, `installPackaged()`, `installPackagedWithADB()`, `uninstall()
 
 Events: `"appOpen"`, `"appClose"`, `"appInstall"`, `"appUninstall"`
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A limited set of the API (`Console`, `StyleSheets`) is compatible with the [Simu
 `client.listTabs()` will expose the webapp, with various utility function around webapps and also allows to have `Tab` instances for each running app.
 
 ```
-client.Webapps(function(err, webapps) {
+client.getWebapps(function(err, webapps) {
   webapps.getApp("app://homescreen.gaiamobile.org/manifest.webapp", function (err, app) {
     console.log("homescreen:", actor.url);
     app.Console.evaluateJS("alert('foo')", function(err, resp) {
@@ -87,7 +87,7 @@ tab.Console.on("page-error", function(event) {
 Summary of the offerings of the modules and objects:
 
 #### [FirefoxClient](http://github.com/harthur/firefox-client/wiki/FirefoxClient)
-Methods: `connect()`, `disconnect()`, `listTabs()`, `selectedTab()`, `Webapps()`, `Root()`
+Methods: `connect()`, `disconnect()`, `listTabs()`, `selectedTab()`, `getWebapps()`, `Root()`
 
 Events: `"error"`, `"timeout"`, `"end"`
 
@@ -139,7 +139,7 @@ Methods: `getText()`, `update()`, `toggleDisabled()`, `getOriginalSources()`
 Events: `"disabled-changed"`, `"ruleCount-changed"`
 
 #### Webapps
-Methods: `listRunningApps()`, `getInstalledApps()`, `watchApps()`, `unwatchApps()`, `launch()`, `close()`, `getApp()`, `installHosted()`, `installPackaged()`, `installPackagedWithADB()`, `uninstall()
+Methods: `listRunningApps()`, `getInstalledApps()`, `watchApps()`, `unwatchApps()`, `launch()`, `close()`, `getApp()`, `installHosted()`, `installPackaged()`, `installPackagedWithADB()`, `uninstall()`
 
 Events: `"appOpen"`, `"appClose"`, `"appInstall"`, `"appUninstall"`
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ var FirefoxClient = require("firefox-client");
 var client = new FirefoxClient();
 
 client.connect(6000, function() {
-  client.listTabs(function(err, tabs) {
+  client.listTabs(function(err, tabs, actors) {
     console.log("first tab:", tabs[0].url);
   });
 });
@@ -35,10 +35,26 @@ npm install firefox-client
 ### Firefox for Android
 Follow the instructions in [this Hacks video](https://www.youtube.com/watch?v=Znj_8IFeTVs)
 
-### Firefox OS Simulator
+### Firefox OS 1.1 Simulator
 A limited set of the API (`Console`, `StyleSheets`) is compatible with the [Simulator 4.0](https://addons.mozilla.org/en-US/firefox/addon/firefox-os-simulator/). See the [wiki instructions](https://github.com/harthur/firefox-client/wiki/Firefox-OS-Simulator-Instructions) for connecting.
 
 `client.listTabs()` will list the currently open apps in the Simulator.
+
+### Firefox OS 1.2+ Simulator and devices
+
+`client.listTabs()` will expose the webapps actor, with various utility function around webapps and also allows to have `Tab` instances for each running app.
+
+```
+client.listTabs(function(err, tabs, actors) {
+  var webapps = actors.webapps;
+  webapps.getAppActor("app://homescreen.gaiamobile.org/manifest.webapp", function (err, actor) {
+    console.log("homescreen:", actor.url);
+    actor.Console.evaluateJS("alert('foo')", function(err, resp) {
+      console.log("alert dismissed");
+    });
+  });
+});
+```
 
 ## Compatibility
 
@@ -123,9 +139,16 @@ Methods: `getText()`, `update()`, `toggleDisabled()`, `getOriginalSources()`
 
 Events: `"disabled-changed"`, `"ruleCount-changed"`
 
+#### Webapps
+Methods: `listRunningApps()`, `getInstalledApps()`, `watchApps()`, `unwatchApps()`, `launch()`, `close()`, `getAppActor()`, `installHosted()`, `installPackaged()`, `installPackagedWithADB()`, `uninstall()
+
+Events: `"appOpen"`, `"appClose"`, `"appInstall"`, `"appUninstall"`
+
 ## Examples
 
 [fxconsole](https://github.com/harthur/fxconsole) - a remote JavaScript console for Firefox
+
+[webapps test script](https://pastebin.mozilla.org/5094843) - a sample usage of all webapps features
 
 ## Feedback
 

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -82,15 +82,31 @@ FirefoxClient.prototype = extend(ClientMethods, {
         var tabs = resp.tabs.map(function(tab) {
           return new Tab(this.client, tab);
         }.bind(this));
-
-        var rootActors = {
-          webapps: new Webapps(this.client, resp)
-        };
-        if (resp.consoleActor) {
-          rootActors.root = new Tab(this.client, resp);
-        }
-        cb(null, tabs, rootActors);
+        cb(null, tabs);
       }
     }.bind(this));
+  },
+
+  Webapps: function(cb) {
+    this.request("listTabs", (function(err, resp) {
+      if (err) {
+        return cb(err);
+      }
+      var webapps = new Webapps(this.client, resp);
+      cb(null, webapps);
+    }).bind(this));
+  },
+
+  Root: function(cb) {
+    this.request("listTabs", (function(err, resp) {
+      if (err) {
+        return cb(err);
+      }
+      if (!resp.consoleActor) {
+        return cb("No root actor being available.");
+      }
+      var root = new Tab(this.client, resp);
+      cb(null, root);
+    }).bind(this));
   }
 })

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -87,7 +87,7 @@ FirefoxClient.prototype = extend(ClientMethods, {
     }.bind(this));
   },
 
-  Webapps: function(cb) {
+  getWebapps: function(cb) {
     this.request("listTabs", (function(err, resp) {
       if (err) {
         return cb(err);
@@ -97,7 +97,7 @@ FirefoxClient.prototype = extend(ClientMethods, {
     }).bind(this));
   },
 
-  Root: function(cb) {
+  getRoot: function(cb) {
     this.request("listTabs", (function(err, resp) {
       if (err) {
         return cb(err);

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -2,6 +2,7 @@ var extend = require("./extend"),
     ClientMethods = require("./client-methods"),
     Client = require("./client"),
     Tab = require("./tab"),
+    Webapps = require("./webapps"),
     SimulatorApps = require("./simulator");
 
 const DEFAULT_PORT = 6000;
@@ -82,7 +83,13 @@ FirefoxClient.prototype = extend(ClientMethods, {
           return new Tab(this.client, tab);
         }.bind(this));
 
-        cb(null, tabs);
+        var rootActors = {
+          webapps: new Webapps(this.client, resp)
+        };
+        if (resp.consoleActor) {
+          rootActors.root = new Tab(this.client, resp);
+        }
+        cb(null, tabs, rootActors);
       }
     }.bind(this));
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,7 +17,11 @@ var unsolicitedEvents = {
   "networkEventUpdate": "networkEventUpdate",
   "networkEvent": "networkEvent",
   "propertyChange": "propertyChange",
-  "newMutations": "newMutations"
+  "newMutations": "newMutations",
+  "appOpen": "appOpen",
+  "appClose": "appClose",
+  "appInstall": "appInstall",
+  "appUninstall": "appUninstall"
 };
 
 /**

--- a/lib/webapps.js
+++ b/lib/webapps.js
@@ -1,0 +1,166 @@
+var extend = require("./extend"),
+    ClientMethods = require("./client-methods"),
+    Tab = require("./tab"),
+    fs = require("fs"),
+    spawn = require("child_process").spawn;
+
+module.exports = Webapps;
+
+var CHUNK_SIZE = 20480;
+
+// Also dispatch appOpen/appClose, appInstall/appUninstall events
+function Webapps(client, tab) {
+  this.initialize(client, tab.webappsActor);
+}
+
+Webapps.prototype = extend(ClientMethods, {
+  watchApps: function(cb) {
+    this.request("watchApps", cb);
+  },
+  unwatchApps: function(cb) {
+    this.request("unwatchApps", cb);
+  },
+  launch: function(manifestURL, cb) {
+    this.request("launch", {manifestURL: manifestURL}, cb);
+  },
+  close: function(manifestURL, cb) {
+    this.request("close", {manifestURL: manifestURL}, cb);
+  },
+  getInstalledApps: function(cb) {
+    this.request("getAll", function (err, resp) {
+      if (err) {
+        cb(err);
+        return;
+      }
+      cb(null, resp.apps); 
+    });
+  },
+  listRunningApps: function(cb) {
+    this.request("listRunningApps", function (err, resp) {
+      if (err) {
+        cb(err);
+        return;
+      }
+      cb(null, resp.apps); 
+    });
+  },
+  getAppActor: function(manifestURL, cb) {
+    this.request("getAppActor", {manifestURL: manifestURL}, (function (err, resp) {
+      var actor = new Tab(this.client, resp.actor);
+      cb(null, actor);
+    }).bind(this));
+  },
+  installHosted: function(options, cb) {
+    this.request(
+      "install",
+      { appId: options.appId,
+        metadata: options.metadata,
+        manifest: options.manifest },
+      function (err, resp) {
+        if (err || resp.error) {
+          cb(err || resp.error);
+          return;
+        }
+        cb(null, resp.appId);
+      });
+  },
+  _upload: function (path, cb) {
+    // First create an upload actor
+    this.request("uploadPackage", function (err, resp) {
+      var actor = resp.actor;
+      fs.readFile(path, function(err, data) {
+        chunk(actor, data);
+      });
+    });
+    // Send push the file chunk by chunk
+    var self = this;
+    var step = 0;
+    function chunk(actor, data) {
+      var i = step++ * CHUNK_SIZE;
+      var m = Math.min(i + CHUNK_SIZE, data.length);
+      var c = "";
+      for(; i < m; i++) 
+        c += String.fromCharCode(data[i]);
+      var message = {
+        to: actor,
+        type: "chunk",
+        chunk: c
+      };
+      self.client.makeRequest(message, function(resp) {
+        if (resp.error) {
+          cb(resp);
+          return;
+        }
+        if (i < data.length) {
+          setTimeout(chunk, 0, actor, data);
+        } else {
+          done(actor);
+        }
+      });
+    }
+    // Finally close the upload
+    function done(actor) {
+      var message = {
+        to: actor,
+        type: "done"
+      };
+      self.client.makeRequest(message, function(resp) {
+        if (resp.error) {
+          cb(resp);
+        } else {
+          cb(null, actor, cleanup.bind(null, actor));
+        }
+      });
+    }
+
+    // Remove the temporary uploaded file from the server:
+    function cleanup(actor) {
+      var message = {
+        to: actor,
+        type: "remove"
+      };
+      self.client.makeRequest(message, function () {});
+    }
+  },
+  installPackaged: function(path, appId, cb) {
+    this._upload(path, (function (err, actor, cleanup) {
+      this.request("install", {appId: appId, upload: actor},
+        function (err, resp) {
+          if (err) {
+            cb(err);
+            return;
+          }
+          cb(null, resp.appId);
+          cleanup();
+        });
+    }).bind(this));
+  },
+  installPackagedWithADB: function(path, appId, cb) {
+    var self = this;
+    // First ensure the temporary folder exists
+    function createTemporaryFolder() {
+      var c = spawn("adb", ["shell", "mkdir -p /data/local/tmp/b2g/" + appId], {stdio:"inherit"});
+      c.on("close", uploadPackage);
+    }
+    // then upload the package to the temporary directory
+    function uploadPackage() {
+      var child = spawn("adb", ["push", path, "/data/local/tmp/b2g/" + appId + "/application.zip"], {stdio:"inherit"});
+      child.on("close", installApp);
+    }
+    // finally order the webapps actor to install the app
+    function installApp() {
+      self.request("install", {appId: appId},
+        function (err, resp) {
+          if (err) {
+            cb(err);
+            return;
+          }
+          cb(null, resp.appId);
+        });
+    }
+    createTemporaryFolder();
+  },
+  uninstall: function(manifestURL, cb) {
+    this.request("uninstall", {manifestURL: manifestURL}, cb);
+  }
+})

--- a/lib/webapps.js
+++ b/lib/webapps.js
@@ -44,7 +44,7 @@ Webapps.prototype = extend(ClientMethods, {
       cb(null, resp.apps); 
     });
   },
-  getAppActor: function(manifestURL, cb) {
+  getApp: function(manifestURL, cb) {
     this.request("getAppActor", {manifestURL: manifestURL}, (function (err, resp) {
       var actor = new Tab(this.client, resp.actor);
       cb(null, actor);


### PR DESCRIPTION
People keep asking for being able to push apps to b2g desktop/device from the command line.
firefox-client looks like the best implementation of devtools protocol client and I would like to promote it as the best way to write a command line tool for b2g.

Here is a pretty significant patch, that allows accessing the webapps global actor (bonus: it also exposes the root actor) and implement various helper to ease using all webapps actor feature.

Thanks you so much @harthur for providing this library, it was really easy to tweak it to support webapps actor!!

Here is a hardcoded test app script that allows testing all these methods: https://pastebin.mozilla.org/5094843

@RudyLu, you pinged me sooner this morning. I did that by thinking about your usecase. Hopefully you can use this for your needs! (See the pastebin)
