### PR TITLE
Workaround for segfaults on OS X caused by node issue 25357

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -192,6 +192,11 @@ Client.prototype = extend(events.EventEmitter.prototype, {
    * otherwise.
    */
   readMessage: function() {
+
+    // HACK: This is a magical mystery workaround for a node.js bug
+    // see also - https://github.com/joyent/node/issues/25357
+    var copy = new Buffer(this.incoming);
+
     var sep = this.incoming.toString().indexOf(':');
     if (sep < 0) {
       return false;


### PR DESCRIPTION
see also - https://github.com/joyent/node/issues/25357

There's a bug in node>=0.11.0 that causes segfaults on OS X. This seems to prevent the segfault, but the reason why is a mystery.

Submitting this PR in the off chance this seems not entirely insane to accept & publish to npm
